### PR TITLE
typescript definitions + remove unnecessary warning

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -1,0 +1,46 @@
+export interface ServerDetails {
+  server: string;
+  domainId: string;
+}
+
+export interface TrackingOptions {
+  /**
+   * Defaults to `true`
+   */
+  ignoreLocalhost?: boolean;
+  /**
+   * Defaults to `false`
+   */
+  detailed?: boolean;
+}
+
+export interface DefaultData {
+  siteLocation: string;
+  siteReferrer: string;
+}
+
+// Based on https://github.com/bestiejs/platform.js/blob/master/platform.js
+export interface DetailedData {
+  siteLanguage: string;
+  screenWidth: number;
+  screenHeight: number;
+  screenColorDepth: number;
+  deviceName: string | null;
+  deviceManufacturer: string | null;
+  osName: string | null;
+  osVersion: string | null;
+  browserName: string | null;
+  browserVersion: string | null;
+  browserWidth: number;
+  browserHeight: number;
+}
+
+export function attributes(detailed: true): DefaultData & DetailedData;
+export function attributes(detailed?: false): DefaultData;
+
+export function detect(): void;
+
+export function create(
+  serverDetails: ServerDetails,
+  options?: TrackingOptions
+): { record: (attrs?: ReturnType<typeof attributes>) => () => void };

--- a/package.json
+++ b/package.json
@@ -6,6 +6,7 @@
   ],
   "description": "Transfer data to Ackee",
   "main": "dist/ackee-tracker.min.js",
+  "types": "index.d.ts",
   "keywords": [
     "ackee",
     "tracking",
@@ -24,7 +25,8 @@
   },
   "files": [
     "dist",
-    "src"
+    "src",
+    "index.d.ts"
   ],
   "devDependencies": {
     "rosid-handler-js": "^13.0.0"

--- a/src/scripts/main.js
+++ b/src/scripts/main.js
@@ -260,12 +260,6 @@ export const create = function({ server, domainId }, opts) {
 }
 
 // Only run Ackee automatically when executed in a browser environment
-if (isBrowser === true) {
-
+if (isBrowser) {
 	detect()
-
-} else {
-
-	console.warn('Ackee is not executing automatically because you are using it in an environment without a `window` object')
-
 }

--- a/test.ts
+++ b/test.ts
@@ -1,0 +1,29 @@
+import * as Ackee from ".";
+
+const attributes = Ackee.attributes(true);
+const attributes2 = Ackee.attributes(false);
+const attributes3 = Ackee.attributes();
+
+const instance = Ackee.create({
+  server: "",
+  domainId: "",
+});
+
+const stop = instance.record(attributes);
+
+stop();
+
+const stop2 = instance.record();
+
+stop2();
+
+const instance2 = Ackee.create(
+  {
+    server: "",
+    domainId: "",
+  },
+  {
+    ignoreLocalhost: false,
+    detailed: true,
+  }
+);


### PR DESCRIPTION
I wanted to implement [use-ackee](https://github.com/electerious/use-ackee) in a Next.js project programmatically as mentioned in #15 but I realized there are no TypeScript definitions neither in `ackee-tracker` or `use-ackee`, and to do things right I need the definitions in here before making them for `use-ackee`.

I also had to remove the warning `Ackee is not executing automatically...` on server side because in any server side rendering project it would print it in every page (in console) for nothing. 